### PR TITLE
[로그인 유지 기능] 토글 방식 로그인 유지 기능 구현 + 비밀번호 변경 인증 방식 추가

### DIFF
--- a/api/my/APIDetail.ts
+++ b/api/my/APIDetail.ts
@@ -49,5 +49,5 @@ export class UpdatePassword implements APIRequest<string> {
   response!: string;
   auth = true;
 
-  constructor(public authorization: string, public data: { newPassword: string }) {}
+  constructor(public authorization: string, public data: EditPasswordRequest) {}
 }

--- a/api/my/APIDetail.ts
+++ b/api/my/APIDetail.ts
@@ -1,6 +1,22 @@
 import { APIRequest, HTTP_METHOD } from '@/api/APIRequest';
-import { SignUpRequest, SignUpResponse, UserInfoResponse, DeleteUserResponse, LoginRequest, LoginResponse, EditPasswordRequest } from './entity';
+import { 
+  SignUpRequest, 
+  SignUpResponse, 
+  UserInfoResponse, 
+  DeleteUserResponse, 
+  LoginRequest, 
+  LoginResponse, 
+  EditPasswordRequest, 
+  FindEmailResponse,
+  SendCodeRequest,
+  SendCodeResponse,
+  CheckCodeRequest,
+  CheckCodeResponse,
+  ResetPasswordRequest,
+  ResetPasswordResponse, 
+} from './entity';
 
+// 유저 탈퇴
 export class DeleteUser<R extends DeleteUserResponse> implements APIRequest<R> {
   method = HTTP_METHOD.DELETE;
   path: string;
@@ -12,6 +28,7 @@ export class DeleteUser<R extends DeleteUserResponse> implements APIRequest<R> {
   }
 }
 
+// 유저 정보 조회
 export class GetUserInfo<R extends UserInfoResponse> implements APIRequest<R> {
   method = HTTP_METHOD.GET;
   path: string;
@@ -23,6 +40,7 @@ export class GetUserInfo<R extends UserInfoResponse> implements APIRequest<R> {
   }
 }
 
+// 유저 회원가입
 export class PostSignUp<R extends SignUpResponse> implements APIRequest<R> {
   method = HTTP_METHOD.POST;
   path: string;
@@ -34,6 +52,7 @@ export class PostSignUp<R extends SignUpResponse> implements APIRequest<R> {
   }
 }
 
+// 유저 로그인
 export class PostLogin implements APIRequest<LoginResponse> {
   method = HTTP_METHOD.POST;
   path = '/swagger-auth/login';
@@ -43,6 +62,7 @@ export class PostLogin implements APIRequest<LoginResponse> {
   constructor(public data: LoginRequest) {}
 }
 
+// 유저 비밀번호 수정
 export class UpdatePassword implements APIRequest<string> {
   method = HTTP_METHOD.PUT;
   path = '/user/update-password';
@@ -50,4 +70,48 @@ export class UpdatePassword implements APIRequest<string> {
   auth = true;
 
   constructor(public authorization: string, public data: EditPasswordRequest) {}
+}
+
+// 이메일 존재 여부 판단
+export class GetFindEmail implements APIRequest<FindEmailResponse> {
+  method = HTTP_METHOD.GET;
+  path = '/user/find-email';
+  response!: FindEmailResponse;
+  auth = false;
+  params: { email: string };
+
+  constructor(public email: string) {
+    this.params = { email };
+  }
+}
+
+// 유저에게 인증번호 전송
+export class PostSendCode implements APIRequest<SendCodeResponse> {
+  method = HTTP_METHOD.POST;
+  path = '/user/send-code';
+  response!: SendCodeResponse;
+  auth = false;
+
+  constructor(public data: SendCodeRequest) {}
+}
+
+
+// 인증번호 확인 및 비밀번호 확인
+export class PostCheckCode implements APIRequest<CheckCodeResponse> {
+  method = HTTP_METHOD.POST;
+  path = '/user/check-code';
+  response!: CheckCodeResponse;
+  auth = false;
+
+  constructor(public data: CheckCodeRequest) {}
+}
+
+// 비밀번호 재설정(초기화)
+export class PutResetPassword implements APIRequest<ResetPasswordResponse> {
+  method = HTTP_METHOD.PUT;
+  path = '/user/reset-password';
+  response!: ResetPasswordResponse;
+  auth = false;
+
+  constructor(public data: ResetPasswordRequest) {}
 }

--- a/api/my/APIDetail.ts
+++ b/api/my/APIDetail.ts
@@ -75,13 +75,12 @@ export class UpdatePassword implements APIRequest<string> {
 // 이메일 존재 여부 판단
 export class GetFindEmail implements APIRequest<FindEmailResponse> {
   method = HTTP_METHOD.GET;
-  path = '/user/find-email';
+  path: string;
   response!: FindEmailResponse;
   auth = false;
-  params: { email: string };
 
   constructor(public email: string) {
-    this.params = { email };
+    this.path = `/user/find-email?email=${email}`;
   }
 }
 

--- a/api/my/entity.ts
+++ b/api/my/entity.ts
@@ -27,6 +27,7 @@ export interface SignUpResponse extends APIResponse {
     message: string;
 }
 
+// 로그인
 export type LoginRequest = {
     email: string;
     password: string;
@@ -37,7 +38,34 @@ export interface LoginResponse {
     refreshToken: string;
 }
 
+// 유저 정보 수정
 export interface EditPasswordRequest {
     currentPassword: string;
     newPassword: string;
 }
+
+// 이메일 존재 여부 판단
+export type FindEmailResponse = string;
+
+// 인증번호 전송
+export type SendCodeRequest = {
+  email: string;
+};
+
+export type SendCodeResponse = string;
+
+// 인증번호 확인 및 비밀번호 확인
+export type CheckCodeRequest = {
+  email: string;
+  code: string;
+};
+
+export type CheckCodeResponse = string;
+
+// 비밀번호 재설정(초기화)
+export type ResetPasswordRequest = {
+  email: string;
+  newPassword: string;
+};
+
+export type ResetPasswordResponse = string;

--- a/api/my/entity.ts
+++ b/api/my/entity.ts
@@ -39,8 +39,7 @@ export interface LoginResponse {
 }
 
 // 유저 정보 수정
-export interface EditPasswordRequest {
-    currentPassword: string;
+export interface EditPasswordRequest {    
     newPassword: string;
 }
 

--- a/api/my/entity.ts
+++ b/api/my/entity.ts
@@ -38,5 +38,6 @@ export interface LoginResponse {
 }
 
 export interface EditPasswordRequest {
+    currentPassword: string;
     newPassword: string;
 }

--- a/api/my/index.ts
+++ b/api/my/index.ts
@@ -1,5 +1,14 @@
 import APIClient from '@/api/apiClient';
-import { GetUserInfo, PostSignUp, DeleteUser, PostLogin, UpdatePassword } from './APIDetail';
+import { 
+    GetUserInfo, 
+    PostSignUp, 
+    DeleteUser, 
+    PostLogin, 
+    UpdatePassword, 
+    GetFindEmail,
+    PostSendCode,
+    PostCheckCode,
+    PutResetPassword, } from './APIDetail';
 
 export const deleteUser = APIClient.of(DeleteUser);
 
@@ -10,3 +19,11 @@ export const postSignUp = APIClient.of(PostSignUp);
 export const postLogin = APIClient.of(PostLogin);
 
 export const updatePassword = APIClient.of(UpdatePassword);
+
+export const getFindEmail = APIClient.of(GetFindEmail);
+
+export const postSendCode = APIClient.of(PostSendCode);
+
+export const postCheckCode = APIClient.of(PostCheckCode);
+
+export const putResetPassword = APIClient.of(PutResetPassword);

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,10 +46,14 @@ export default function RootLayout() {
   useEffect(() => {
     const checkLoginStatus = async () => {
       const token = await AsyncStorage.getItem('accessToken');
-      if (!token) {
+      const autoLogin = await AsyncStorage.getItem('autoLogin');
+
+      if (token && autoLogin === 'true') {
+        router.replace('/(tabs)');
+      } else {
         showToast('info', '로그인 필요', '로그인이 필요합니다.');  
+        router.replace('/signIn');
       }
-      router.replace('/signIn');
     };
 
     if (!isSplashVisible) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -72,8 +72,8 @@ export default function RootLayout() {
   ) : (
     <QueryClientProvider client={queryClient}>
       <Stack>
-        <Stack.Screen name="signUp" options={{ headerShown: true, title: '', headerShadowVisible: false, headerStyle: commonStyles.headerStyle, headerTintColor: '#D6DEFD', }} />
         <Stack.Screen name="signIn" options={{ headerShown: false }} />
+        <Stack.Screen name="signUp" options={{ headerShown: true, title: '', headerShadowVisible: false, headerStyle: commonStyles.headerStyle, headerTintColor: '#D6DEFD', }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }}/>
         <Stack.Screen name="setting" options={{ headerShown: true, title: '', headerShadowVisible: false, headerStyle: commonStyles.headerStyle, headerTintColor: '#D6DEFD',}} />
         <Stack.Screen name="edit-password" options={{ headerShown: true, title: '', headerShadowVisible: false, headerStyle: commonStyles.headerStyle, headerTintColor: '#D6DEFD',}} />

--- a/app/edit-password/index.tsx
+++ b/app/edit-password/index.tsx
@@ -16,10 +16,16 @@ import { updatePassword } from '@/api/my';
 const EditPassword = () => {
   const router = useRouter();
   const showToast = useShowToast();
+  const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  const handlePasswordChange = async () => {  
+  const handlePasswordChange = async () => { 
+    if (!currentPassword.trim()) {
+      showToast('error', '입력 필요', '현재 비밀번호를 입력해주세요.');
+      return;
+    }
+
     if (!newPassword.trim()) {
       showToast('error', '입력 필요', '새 비밀번호를 입력해주세요.');
       return;
@@ -42,12 +48,11 @@ const EditPassword = () => {
     }
   
     try {
-      const result = await updatePassword(token, { newPassword });
-      // showToast('success', '비밀번호 변경 완료', result || '다시 로그인해주세요.');
+      const result = await updatePassword(token, { currentPassword, newPassword });
+      console.log(result);   
       showToast('success', '비밀번호 변경 완료', '다시 로그인해주세요.');
       router.replace('/signIn');
-    } catch (error: any) {
-      // showToast('error', '에러 발생', error.message || '비밀번호 변경 실패');
+    } catch (error: any) {      
       showToast('error', '비밀번호 변경 실패', '비밀 번호 변경에 실패하였습니다.');
     }
   };
@@ -62,6 +67,15 @@ const EditPassword = () => {
             <Text style={styles.headerText}>비밀번호 변경</Text>
           </View>
           <View style={styles.contentContainer}>
+            <View>
+              <Text style={styles.label}>현재 비밀번호</Text>
+              <TextInput
+                style={styles.input}
+                secureTextEntry
+                value={currentPassword}
+                onChangeText={setCurrentPassword}
+              />
+            </View>
             <View>
               <Text style={styles.label}>새 비밀번호</Text>
               <TextInput

--- a/app/edit-password/index.tsx
+++ b/app/edit-password/index.tsx
@@ -15,17 +15,11 @@ import { updatePassword } from '@/api/my';
 
 const EditPassword = () => {
   const router = useRouter();
-  const showToast = useShowToast();
-  const [currentPassword, setCurrentPassword] = useState('');
+  const showToast = useShowToast();  
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  const handlePasswordChange = async () => { 
-    if (!currentPassword.trim()) {
-      showToast('error', '입력 필요', '현재 비밀번호를 입력해주세요.');
-      return;
-    }
-
+  const handlePasswordChange = async () => {
     if (!newPassword.trim()) {
       showToast('error', '입력 필요', '새 비밀번호를 입력해주세요.');
       return;
@@ -48,12 +42,12 @@ const EditPassword = () => {
     }
   
     try {
-      const result = await updatePassword(token, { currentPassword, newPassword });
+      const result = await updatePassword(token, { newPassword });
       console.log(result);   
       showToast('success', '비밀번호 변경 완료', '다시 로그인해주세요.');
       router.replace('/signIn');
     } catch (error: any) {      
-      showToast('error', '비밀번호 변경 실패', '비밀 번호 변경에 실패하였습니다.');
+      showToast('error', '비밀번호 변경 실패', '기존 비밀번호와 같습니다.');
     }
   };
   return (
@@ -66,16 +60,7 @@ const EditPassword = () => {
           <View style={styles.headerContainer}>
             <Text style={styles.headerText}>비밀번호 변경</Text>
           </View>
-          <View style={styles.contentContainer}>
-            <View>
-              <Text style={styles.label}>현재 비밀번호</Text>
-              <TextInput
-                style={styles.input}
-                secureTextEntry
-                value={currentPassword}
-                onChangeText={setCurrentPassword}
-              />
-            </View>
+          <View style={styles.contentContainer}>            
             <View>
               <Text style={styles.label}>새 비밀번호</Text>
               <TextInput

--- a/app/setting/index.tsx
+++ b/app/setting/index.tsx
@@ -67,6 +67,7 @@ function SettingScreen() {
       await deleteUser(token);
       showToast('success', '회원 탈퇴 완료', '그동안 이용해주셔서 감사합니다.');
       await AsyncStorage.removeItem('accessToken');
+      await AsyncStorage.removeItem('autoLogin');
       router.replace('/signIn');
     } catch (error) {
       showToast('error', '회원 탈퇴 실패', '다시 시도해주세요.');

--- a/app/setting/index.tsx
+++ b/app/setting/index.tsx
@@ -51,6 +51,7 @@ function SettingScreen() {
 
   const handleLogout = async () => {
     await AsyncStorage.removeItem('accessToken');
+    await AsyncStorage.removeItem('autoLogin');
     showToast('success', '로그아웃 되었습니다.', '다음에 또 만나요 👋');
     router.replace('/signIn');
   };
@@ -66,8 +67,7 @@ function SettingScreen() {
     try {
       await deleteUser(token);
       showToast('success', '회원 탈퇴 완료', '그동안 이용해주셔서 감사합니다.');
-      await AsyncStorage.removeItem('accessToken');
-      await AsyncStorage.removeItem('autoLogin');
+      await AsyncStorage.removeItem('accessToken');      
       router.replace('/signIn');
     } catch (error) {
       showToast('error', '회원 탈퇴 실패', '다시 시도해주세요.');

--- a/app/setting/index.tsx
+++ b/app/setting/index.tsx
@@ -51,7 +51,7 @@ function SettingScreen() {
 
   const handleLogout = async () => {
     await AsyncStorage.removeItem('accessToken');
-    await AsyncStorage.removeItem('autoLogin');
+    await AsyncStorage.removeItem('autoLogin');    
     showToast('success', '로그아웃 되었습니다.', '다음에 또 만나요 👋');
     router.replace('/signIn');
   };

--- a/app/signIn.tsx
+++ b/app/signIn.tsx
@@ -29,12 +29,12 @@ function SignInScreen() {
 
   const handleLogin = () => {
     if (!email || !password) {
-      showToast('error', '입력 오류', '이메일과 비밀번호를 모두 입력하세요.');
+      showToast('error', '입력 오류', '이메일과 비밀번호를 모두 입력해주세요.');
       return;
     }
     const emailRegex = /\S+@\S+\.\S+/;
     if (!emailRegex.test(email)) {
-      showToast('error', '이메일 오류', '유효한 이메일 형식을 입력하세요.');
+      showToast('error', '이메일 오류', '유효한 이메일 형식을 입력해주세요.');
       return;
     }
     login(email, password, autoLogin);
@@ -48,12 +48,12 @@ function SignInScreen() {
     }
     findEmailMutation.mutate(resetEmail, {
       onSuccess: () => {
-        showToast('success', '이메일 확인', '인증코드를 전송합니다.');
+        showToast('success', '이메일 확인', '해당 이메일로 인증코드를 전송했습니다.');
         setEmailChecked(true);
         sendCodeMutation.mutate(resetEmail);
       },
       onError: (err) => {
-        showToast('error', '존재하지 않는 이메일', "해당 이메일은 존재하지 않습니다.");
+        showToast('error', '존재하지 않는 이메일', "존재하지 않는 이메일 주소입니다.");
       },
     });
   };
@@ -61,7 +61,7 @@ function SignInScreen() {
   // check-code 로 이메일로 전송된 인증번호 확인하는 부분
   const handleResetCodeCheck = () => {
     if (!resetCode.trim()) {
-      showToast('error', '입력 오류', '인증코드를 입력해주세요.');
+      showToast('error', '입력 필요', '인증코드를 입력해주세요.');
       return;
     }
     checkCodeMutation.mutate({ email: resetEmail, code: resetCode }, {
@@ -78,7 +78,7 @@ function SignInScreen() {
   // reset-password 로 비밀번호 변경하는 부분
   const handleResetPassword = () => {
     if (!resetNewPassword.trim()) {
-      showToast('error', '입력 오류', '새 비밀번호를 입력해주세요.');
+      showToast('error', '입력 없음', '새 비밀번호를 입력해주세요.');
       return;
     }
     resetPasswordMutation.mutate({ email: resetEmail, newPassword: resetNewPassword }, {
@@ -92,7 +92,7 @@ function SignInScreen() {
         setCodeChecked(false);
       },
       onError: (err) => {
-        showToast('error', '오류', err.message);
+        showToast('error', '오류', err.message); // 여기 에러 메시지 수정 필요함!!!!!!!!!!!!!
       },
     });
   };
@@ -146,7 +146,7 @@ function SignInScreen() {
           <Switch
             value={autoLogin}
             onValueChange={setAutoLogin}
-            trackColor={{ false: '#ccc', true: '#84b9ff' }}
+            trackColor={{ false: '#f4f3f4', true: '#007AFF' }}
             thumbColor={autoLogin ? '#007AFF' : '#f4f3f4'} 
             style={styles.autoLoginSwitch}
           />

--- a/app/signIn.tsx
+++ b/app/signIn.tsx
@@ -27,6 +27,7 @@ function SignInScreen() {
     }    
 
     login(email, password, autoLogin);
+    // login(email, password);
   };
 
   useDoubleBackExit(true);

--- a/app/signIn.tsx
+++ b/app/signIn.tsx
@@ -1,11 +1,11 @@
-import { View, Text, TextInput, TouchableOpacity, Switch, ActivityIndicator } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, Switch, ActivityIndicator, Modal } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useState } from 'react';
 import { useSignIn } from '../hooks/useSignIn';
 import useShowToast from '@/hooks/useShowToast';
 import useDoubleBackExit from '@/hooks/useDoubleBackExit';
 import { styles } from '@/styles/signInStyles';
-import { useFindEmail, useSendCode, useCheckCode } from '@/hooks/useEmailVerify';
+import { useFindEmail, useSendCode, useCheckCode, useResetPassword } from '@/hooks/useEmailVerify';
 
 function SignInScreen() {
   const { login, goToSignUp, loading } = useSignIn();
@@ -15,56 +15,17 @@ function SignInScreen() {
   const [password, setPassword] = useState('');
   const [passwordVisible, setPasswordVisible] = useState(false);
 
-  const [emailVerified, setEmailVerified] = useState(false);
-  const [codeSent, setCodeSent] = useState(false);
-  const [code, setCode] = useState('');
+  const [resetModalVisible, setResetModalVisible] = useState(false);
+  const [resetEmail, setResetEmail] = useState('');
+  const [resetCode, setResetCode] = useState('');
+  const [resetNewPassword, setResetNewPassword] = useState('');
+  const [emailChecked, setEmailChecked] = useState(false);
+  const [codeChecked, setCodeChecked] = useState(false);
 
   const findEmailMutation = useFindEmail();
   const sendCodeMutation = useSendCode();
   const checkCodeMutation = useCheckCode();
-
-  const handleEmailVerify = () => {
-    if (!email) {
-      showToast('error', '입력 오류', '이메일을 입력해주세요.');
-      return;
-    }
-    const emailRegex = /\S+@\S+\.\S+/;
-    if (!emailRegex.test(email)) {
-      showToast('error', '형식 오류', '유효한 이메일 형식을 입력하세요.');
-      return;
-    }
-    findEmailMutation.mutate(email, {
-      onSuccess: (res) => {
-        showToast('success', '확인 완료', res);
-        setEmailVerified(true);
-        sendCodeMutation.mutate(email, {
-          onSuccess: (res) => {
-            showToast('success', '인증코드 발송', res);
-            setCodeSent(true);
-          },
-        });
-      },
-      onError: (err: any) => {
-        showToast('error', '이메일 없음', err.message);
-      },
-    });
-  };
-
-  const handleCodeCheck = () => {
-    if (!code) {
-      showToast('error', '입력 오류', '인증코드를 입력해주세요.');
-      return;
-    }
-    checkCodeMutation.mutate({ email, code }, {
-      onSuccess: (res) => {
-        showToast('success', '인증 완료', res);
-        setEmailVerified(true);
-      },
-      onError: (err: any) => {
-        showToast('error', '인증 실패', err.message);
-      },
-    });
-  };
+  const resetPasswordMutation = useResetPassword();
 
   const handleLogin = () => {
     if (!email || !password) {
@@ -77,6 +38,63 @@ function SignInScreen() {
       return;
     }
     login(email, password, autoLogin);
+  };
+
+  // find-email 로 이메일 존재 여부 판단 후 send-code 로 인증번호 전송하는 부분
+  const handleResetEmailCheck = () => {
+    if (!resetEmail.trim()) {
+      showToast('error', '입력 오류', '이메일을 입력해주세요.');
+      return;
+    }
+    findEmailMutation.mutate(resetEmail, {
+      onSuccess: () => {
+        showToast('success', '이메일 확인', '인증코드를 전송합니다.');
+        setEmailChecked(true);
+        sendCodeMutation.mutate(resetEmail);
+      },
+      onError: (err) => {
+        showToast('error', '존재하지 않는 이메일', "해당 이메일은 존재하지 않습니다.");
+      },
+    });
+  };
+
+  // check-code 로 이메일로 전송된 인증번호 확인하는 부분
+  const handleResetCodeCheck = () => {
+    if (!resetCode.trim()) {
+      showToast('error', '입력 오류', '인증코드를 입력해주세요.');
+      return;
+    }
+    checkCodeMutation.mutate({ email: resetEmail, code: resetCode }, {
+      onSuccess: () => {
+        showToast('success', '인증 성공', '새 비밀번호를 입력해주세요.');
+        setCodeChecked(true);
+      },
+      onError: (err) => {
+        showToast('error', '인증 실패', err.message);
+      },
+    });
+  };
+
+  // reset-password 로 비밀번호 변경하는 부분
+  const handleResetPassword = () => {
+    if (!resetNewPassword.trim()) {
+      showToast('error', '입력 오류', '새 비밀번호를 입력해주세요.');
+      return;
+    }
+    resetPasswordMutation.mutate({ email: resetEmail, newPassword: resetNewPassword }, {
+      onSuccess: () => {
+        showToast('success', '완료', '비밀번호가 변경되었습니다.');
+        setResetModalVisible(false);
+        setResetEmail('');
+        setResetCode('');
+        setResetNewPassword('');
+        setEmailChecked(false);
+        setCodeChecked(false);
+      },
+      onError: (err) => {
+        showToast('error', '오류', err.message);
+      },
+    });
   };
 
   useDoubleBackExit(true);
@@ -95,26 +113,6 @@ function SignInScreen() {
         keyboardType="email-address"
         autoCapitalize="none"
       />
-
-      <TouchableOpacity style={styles.emailCheckButton} onPress={handleEmailVerify}>
-        <Text style={styles.emailCheckButtonText}>이메일 확인</Text>
-      </TouchableOpacity>
-
-      {codeSent && (
-        <View style={styles.verificationContainer}>
-          <TextInput
-            placeholder="인증코드 입력"
-            placeholderTextColor="#69728F"
-            style={styles.input}
-            value={code}
-            onChangeText={setCode}
-            keyboardType="numeric"
-          />
-          <TouchableOpacity style={styles.verifyButton} onPress={handleCodeCheck}>
-            <Text style={styles.verifyButtonText}>인증 확인</Text>
-          </TouchableOpacity>
-        </View>
-      )}
 
       <View style={styles.passwordContainer}>
         <TextInput
@@ -142,14 +140,20 @@ function SignInScreen() {
         {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.loginButtonText}>Login</Text>}
       </TouchableOpacity>
 
-      <View style={styles.autoLoginContainer}>
-        <Text style={styles.autoLoginLabel}>자동 로그인</Text>
-        <Switch
-          value={autoLogin}
-          onValueChange={setAutoLogin}
-          trackColor={{ false: '#ccc', true: '#84b9ff' }}
-          thumbColor={autoLogin ? '#007AFF' : '#f4f3f4'}
-        />
+      <View style={styles.bottomRowContainer}>
+        <View style={styles.autoLoginContainer}>
+          <Text style={styles.autoLoginLabel}>자동 로그인</Text>
+          <Switch
+            value={autoLogin}
+            onValueChange={setAutoLogin}
+            trackColor={{ false: '#ccc', true: '#84b9ff' }}
+            thumbColor={autoLogin ? '#007AFF' : '#f4f3f4'} 
+            style={styles.autoLoginSwitch}
+          />
+        </View>
+        <TouchableOpacity onPress={() => setResetModalVisible(true)}>
+          <Text style={styles.resetText}>비밀번호 초기화</Text>
+        </TouchableOpacity>        
       </View>
 
       <View style={styles.signUpContainer}>
@@ -158,6 +162,64 @@ function SignInScreen() {
           <Text style={styles.signUpText}>회원가입하기</Text>
         </TouchableOpacity>
       </View>
+
+      <Modal visible={resetModalVisible} transparent animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalBox}>
+            <Text style={styles.modalTitle}>비밀번호 초기화</Text>
+
+            <TextInput
+              placeholder="이메일 입력"
+              placeholderTextColor="#69728F"
+              style={styles.modalInput}
+              value={resetEmail}
+              onChangeText={setResetEmail}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+
+            <TouchableOpacity style={styles.modalButton} onPress={handleResetEmailCheck}>
+              <Text style={styles.modalButtonText}>이메일 확인</Text>
+            </TouchableOpacity>
+
+            {emailChecked && (
+              <>
+                <TextInput
+                  placeholder="인증번호 입력"
+                  placeholderTextColor="#69728F"
+                  style={styles.modalInput}
+                  value={resetCode}
+                  onChangeText={setResetCode}
+                  keyboardType="numeric"
+                />
+                <TouchableOpacity style={styles.modalButton} onPress={handleResetCodeCheck}>
+                  <Text style={styles.modalButtonText}>코드 확인</Text>
+                </TouchableOpacity>
+              </>
+            )}
+
+            {codeChecked && (
+              <>
+                <TextInput
+                  placeholder="새 비밀번호 입력"
+                  placeholderTextColor="#69728F"
+                  style={styles.modalInput}
+                  value={resetNewPassword}
+                  onChangeText={setResetNewPassword}
+                  secureTextEntry
+                />
+                <TouchableOpacity style={styles.modalButton} onPress={handleResetPassword}>
+                  <Text style={styles.modalButtonText}>비밀번호 변경</Text>
+                </TouchableOpacity>
+              </>
+            )}
+
+            <TouchableOpacity onPress={() => setResetModalVisible(false)} style={styles.modalClose}>
+              <Text style={styles.modalCloseText}>닫기</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }

--- a/app/signIn.tsx
+++ b/app/signIn.tsx
@@ -1,33 +1,82 @@
-import { View, Text, TextInput, TouchableOpacity, Switch } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, Switch, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useState } from 'react';
 import { useSignIn } from '../hooks/useSignIn';
 import useShowToast from '@/hooks/useShowToast';
 import useDoubleBackExit from '@/hooks/useDoubleBackExit';
 import { styles } from '@/styles/signInStyles';
+import { useFindEmail, useSendCode, useCheckCode } from '@/hooks/useEmailVerify';
 
 function SignInScreen() {
   const { login, goToSignUp, loading } = useSignIn();
+  const showToast = useShowToast();
   const [autoLogin, setAutoLogin] = useState(false);
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');  
+  const [password, setPassword] = useState('');
   const [passwordVisible, setPasswordVisible] = useState(false);
 
-  const showToast = useShowToast();
+  const [emailVerified, setEmailVerified] = useState(false);
+  const [codeSent, setCodeSent] = useState(false);
+  const [code, setCode] = useState('');
+
+  const findEmailMutation = useFindEmail();
+  const sendCodeMutation = useSendCode();
+  const checkCodeMutation = useCheckCode();
+
+  const handleEmailVerify = () => {
+    if (!email) {
+      showToast('error', '입력 오류', '이메일을 입력해주세요.');
+      return;
+    }
+    const emailRegex = /\S+@\S+\.\S+/;
+    if (!emailRegex.test(email)) {
+      showToast('error', '형식 오류', '유효한 이메일 형식을 입력하세요.');
+      return;
+    }
+    findEmailMutation.mutate(email, {
+      onSuccess: (res) => {
+        showToast('success', '확인 완료', res);
+        setEmailVerified(true);
+        sendCodeMutation.mutate(email, {
+          onSuccess: (res) => {
+            showToast('success', '인증코드 발송', res);
+            setCodeSent(true);
+          },
+        });
+      },
+      onError: (err: any) => {
+        showToast('error', '이메일 없음', err.message);
+      },
+    });
+  };
+
+  const handleCodeCheck = () => {
+    if (!code) {
+      showToast('error', '입력 오류', '인증코드를 입력해주세요.');
+      return;
+    }
+    checkCodeMutation.mutate({ email, code }, {
+      onSuccess: (res) => {
+        showToast('success', '인증 완료', res);
+        setEmailVerified(true);
+      },
+      onError: (err: any) => {
+        showToast('error', '인증 실패', err.message);
+      },
+    });
+  };
+
   const handleLogin = () => {
     if (!email || !password) {
       showToast('error', '입력 오류', '이메일과 비밀번호를 모두 입력하세요.');
       return;
     }
-    
     const emailRegex = /\S+@\S+\.\S+/;
     if (!emailRegex.test(email)) {
       showToast('error', '이메일 오류', '유효한 이메일 형식을 입력하세요.');
       return;
-    }    
-
+    }
     login(email, password, autoLogin);
-    // login(email, password);
   };
 
   useDoubleBackExit(true);
@@ -46,6 +95,27 @@ function SignInScreen() {
         keyboardType="email-address"
         autoCapitalize="none"
       />
+
+      <TouchableOpacity style={styles.emailCheckButton} onPress={handleEmailVerify}>
+        <Text style={styles.emailCheckButtonText}>이메일 확인</Text>
+      </TouchableOpacity>
+
+      {codeSent && (
+        <View style={styles.verificationContainer}>
+          <TextInput
+            placeholder="인증코드 입력"
+            placeholderTextColor="#69728F"
+            style={styles.input}
+            value={code}
+            onChangeText={setCode}
+            keyboardType="numeric"
+          />
+          <TouchableOpacity style={styles.verifyButton} onPress={handleCodeCheck}>
+            <Text style={styles.verifyButtonText}>인증 확인</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
       <View style={styles.passwordContainer}>
         <TextInput
           placeholder="비밀번호"
@@ -69,8 +139,9 @@ function SignInScreen() {
         onPress={handleLogin}
         disabled={loading}
       >
-        <Text style={styles.loginButtonText}>Login</Text>
+        {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.loginButtonText}>Login</Text>}
       </TouchableOpacity>
+
       <View style={styles.autoLoginContainer}>
         <Text style={styles.autoLoginLabel}>자동 로그인</Text>
         <Switch

--- a/app/signIn.tsx
+++ b/app/signIn.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, Switch } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useState } from 'react';
 import { useSignIn } from '../hooks/useSignIn';
@@ -8,6 +8,7 @@ import { styles } from '@/styles/signInStyles';
 
 function SignInScreen() {
   const { login, goToSignUp, loading } = useSignIn();
+  const [autoLogin, setAutoLogin] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');  
   const [passwordVisible, setPasswordVisible] = useState(false);
@@ -25,7 +26,7 @@ function SignInScreen() {
       return;
     }    
 
-    login(email, password);
+    login(email, password, autoLogin);
   };
 
   useDoubleBackExit(true);
@@ -69,6 +70,15 @@ function SignInScreen() {
       >
         <Text style={styles.loginButtonText}>Login</Text>
       </TouchableOpacity>
+      <View style={styles.autoLoginContainer}>
+        <Text style={styles.autoLoginLabel}>자동 로그인</Text>
+        <Switch
+          value={autoLogin}
+          onValueChange={setAutoLogin}
+          trackColor={{ false: '#ccc', true: '#84b9ff' }}
+          thumbColor={autoLogin ? '#007AFF' : '#f4f3f4'}
+        />
+      </View>
 
       <View style={styles.signUpContainer}>
         <Text style={styles.signUpLabelText}>회원이 아니신가요? </Text>

--- a/hooks/useEmailVerify.ts
+++ b/hooks/useEmailVerify.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { getFindEmail, postSendCode, postCheckCode, putResetPassword } from '@/api/my';
+
+export const useFindEmail = () => {
+  return useMutation({
+    mutationFn: async (email: string) => await getFindEmail(email),
+  });
+};
+
+// 인증번호 전송
+export const useSendCode = () => {
+  return useMutation({
+    mutationFn: async (email: string) => await postSendCode({ email }),
+  });
+};
+
+// 인증번호 확인
+export const useCheckCode = () => {
+  return useMutation({
+    mutationFn: async ({ email, code }: { email: string; code: string }) =>
+      await postCheckCode({ email, code }),
+  });
+};
+
+// 비밀번호 초기화
+export const useResetPassword = () => {
+  return useMutation({
+    mutationFn: async ({ email, newPassword }: { email: string; newPassword: string }) =>
+      await putResetPassword({ email, newPassword }),
+  });
+};

--- a/hooks/useSignIn.ts
+++ b/hooks/useSignIn.ts
@@ -1,21 +1,13 @@
 import { useRouter } from 'expo-router';
 import { useFetchToken } from './useFetchToken';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import useShowToast from './useShowToast';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const useSignIn = () => {
   const router = useRouter();
   const showToast = useShowToast();
   const { fetchToken, loading, error } = useFetchToken();
 
-  // const login = async (email: string, password: string) => {
-  //   try {
-  //     await fetchToken(email, password);
-  //     router.replace('/(tabs)');
-  //   } catch (err: any) {
-  //     showToast('error', '로그인 실패', '이메일 또는 비밀번호가 잘못되었습니다.');
-  //   }
-  // };
   const login = async (email: string, password: string, autoLogin: boolean) => {
   try {
     await fetchToken(email, password);

--- a/hooks/useSignIn.ts
+++ b/hooks/useSignIn.ts
@@ -1,5 +1,6 @@
 import { useRouter } from 'expo-router';
 import { useFetchToken } from './useFetchToken';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import useShowToast from './useShowToast';
 
 export const useSignIn = () => {
@@ -7,14 +8,27 @@ export const useSignIn = () => {
   const showToast = useShowToast();
   const { fetchToken, loading, error } = useFetchToken();
 
-  const login = async (email: string, password: string) => {
-    try {
-      await fetchToken(email, password);
-      router.replace('/(tabs)');
-    } catch (err: any) {
-      showToast('error', '로그인 실패', '이메일 또는 비밀번호가 잘못되었습니다.');
+  // const login = async (email: string, password: string) => {
+  //   try {
+  //     await fetchToken(email, password);
+  //     router.replace('/(tabs)');
+  //   } catch (err: any) {
+  //     showToast('error', '로그인 실패', '이메일 또는 비밀번호가 잘못되었습니다.');
+  //   }
+  // };
+  const login = async (email: string, password: string, autoLogin: boolean) => {
+  try {
+    await fetchToken(email, password);
+    if (autoLogin) {
+      await AsyncStorage.setItem('autoLogin', 'true');
+    } else {
+      await AsyncStorage.removeItem('autoLogin');
     }
-  };
+    router.replace('/(tabs)');
+  } catch (err: any) {
+    showToast('error', '로그인 실패', '이메일 또는 비밀번호가 잘못되었습니다.');
+  }
+};
 
   const goToSignUp = () => {
     router.push('/signUp');

--- a/styles/editProfileStyles.ts
+++ b/styles/editProfileStyles.ts
@@ -26,11 +26,12 @@ export const styles = StyleSheet.create({
     color: '#7A7E9B'
   },
   input: {
+    color: '#FFFFFF',
     borderWidth: 1,
     borderColor: '#69728F',
     borderRadius: 8,
     padding: 15,
-    fontSize: RFValue(16),
+    fontSize: RFValue(13),
   },
   saveButton: {
     backgroundColor: '#D6DEFD',

--- a/styles/signInStyles.ts
+++ b/styles/signInStyles.ts
@@ -120,20 +120,21 @@ export const styles = StyleSheet.create({
         flexDirection: 'row',
         alignItems: 'center',
         marginTop: 10,
-        marginBottom: 10,  
+        marginBottom: 10,
     },
     autoLoginLabel: {
         color: '#D6DEFD',
-        marginRight: 8,  
-        marginBottom: 4,
+        marginRight: 5,  
+        marginBottom: 5,
         fontSize: 15,
     },
     autoLoginSwitch: {
-      transform: [{ scaleX: 0.9 }, { scaleY: 0.9 }],
+      transform: [{ scaleX: 0.87 }, { scaleY: 0.87 }],
     },
     resetText: {
-      color: '#9CB1FF',      
+      color: '#9CB1FF',
       textDecorationLine: 'underline',
+      marginBottom: 3,
       fontSize: 15,
     },
     modalOverlay: {

--- a/styles/signInStyles.ts
+++ b/styles/signInStyles.ts
@@ -34,6 +34,34 @@ export const styles = StyleSheet.create({
         paddingHorizontal: 15,
         marginBottom: 10,
     },
+    emailCheckButton: {
+        backgroundColor: '#4B72FF',
+        paddingVertical: 10,
+        borderRadius: 8,
+        alignItems: 'center',
+        marginBottom: 12,
+    },
+    emailCheckButtonText: {
+        color: '#fff',
+        fontWeight: 'bold',
+    },
+    verificationContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        marginBottom: 12,
+    },
+    verifyButton: {
+        backgroundColor: '#28A745',
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+        borderRadius: 8,
+        justifyContent: 'center',
+    },
+    verifyButtonText: {
+        color: '#fff',
+        fontWeight: 'bold',
+    },
     passwordContainer: {
         width: '100%',
         flexDirection: 'row',

--- a/styles/signInStyles.ts
+++ b/styles/signInStyles.ts
@@ -80,4 +80,14 @@ export const styles = StyleSheet.create({
         fontSize: RFValue(12),
         color: '#989BD2',
     },
+    autoLoginContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginTop: 10,
+        marginBottom: 20,
+    },
+    autoLoginLabel: {
+        color: '#D6DEFD',
+        marginRight: 10,
+    },
 });

--- a/styles/signInStyles.ts
+++ b/styles/signInStyles.ts
@@ -108,14 +108,78 @@ export const styles = StyleSheet.create({
         fontSize: RFValue(12),
         color: '#989BD2',
     },
+    bottomRowContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      width: '90%',
+      paddingHorizontal: 10,
+      marginTop: 10,
+    },
     autoLoginContainer: {
         flexDirection: 'row',
         alignItems: 'center',
         marginTop: 10,
-        marginBottom: 20,
+        marginBottom: 10,  
     },
     autoLoginLabel: {
         color: '#D6DEFD',
-        marginRight: 10,
+        marginRight: 8,  
+        marginBottom: 4,
+        fontSize: 15,
     },
+    autoLoginSwitch: {
+      transform: [{ scaleX: 0.9 }, { scaleY: 0.9 }],
+    },
+    resetText: {
+      color: '#9CB1FF',      
+      textDecorationLine: 'underline',
+      fontSize: 15,
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.6)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalBox: {
+      width: '85%',
+      backgroundColor: '#1C1C1E',
+      padding: 20,
+      borderRadius: 12,
+    },
+    modalTitle: {
+      fontSize: 18,
+      color: '#fff',
+      marginBottom: 10,
+      fontWeight: 'bold',
+    },
+    modalInput: {
+      borderWidth: 1,
+      borderColor: '#ccc',
+      padding: 10,
+      marginTop: 10,
+      color: '#fff',
+      borderRadius: 8,
+    },
+    modalButton: {
+      backgroundColor: '#6F88FF',
+      padding: 10,
+      marginTop: 10,
+      alignItems: 'center',
+      borderRadius: 8,
+    },
+    modalButtonText: {
+      color: '#fff',
+      fontWeight: 'bold',
+    },
+    modalClose: {
+      marginTop: 10,
+      alignItems: 'center',
+    },
+    modalCloseText: {
+      color: '#ccc',
+      fontSize: 13,
+    },
+
 });


### PR DESCRIPTION
<img width="308" alt="image" src="https://github.com/user-attachments/assets/073b6f43-f0ce-4013-b0b6-2b0ef7695d4e" />
<img width="306" alt="image" src="https://github.com/user-attachments/assets/8001ce9a-bec1-4c94-8b92-f624b322ce95" />


토글 방식의 로그인 유지 on/off 기능 탑재
- 자동 로그인 on 시 로그아웃 버튼을 클릭하지 않는 이상 앱을 실행할 때 자동으로 로그인 페이지를 넘기고 홈 화면으로 가도록 구현

<img width="308" alt="image" src="https://github.com/user-attachments/assets/f12fc657-33d7-438e-a5ed-a419ba0c2895" />

이메일 인증을 통한 비밀번호 초기화 기능 탑재
- '이메일 존재 여부, 해당 이메일로 인증코드 전송, 인증 완료 시 비밀번호 초기화' 의 순서로 비밀번호 초기화 기능 구현